### PR TITLE
fix: machine file expired check

### DIFF
--- a/src/licensed/license.rs
+++ b/src/licensed/license.rs
@@ -124,7 +124,7 @@ impl License {
         // expiration flag
         let minutes_to_expiry = expiry.signed_duration_since(now).num_minutes();
 
-        let valid = minutes_since_issued > 0 && minutes_to_expiry > 0;
+        let valid = minutes_since_issued >= 0 && minutes_to_expiry > 0;
 
         Ok(!valid)
     }


### PR DESCRIPTION
## Fixed Issue https://github.com/bagindo/tauri-plugin-keygen/issues/4

### Problem

The check of machine file expiration was valid only if minutes difference between "now" and issued time was greater than 0.
